### PR TITLE
Upgrade to R4

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,4 @@
+^renv$
+^renv\.lock$
 ^.*\.Rproj$
 ^\.Rproj\.user$

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -12,8 +12,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: "3.6.1"}
-          - {os: macOS-latest,   r: "3.6.1"}
+          - {os: windows-latest, r: "4.0.5"}
+          - {os: macOS-latest,   r: "4.0.5"}
+          - {os: ubuntu-20.04,   r: "4.0.5"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -30,6 +30,12 @@ jobs:
 
       - uses: jasp-stats/jasp-actions/setup-test-env@master
 
+      # so Rstudio's binary for igraph appears to be incompatible (i.e., crashes hard) with GitHub actions. Instead, we install igraph from source
+      - name: Make sure igraph is installed from source
+        if: ${{ runner.os == 'Linux' }}
+        run: install.packages("igraph", type = "source", repos = "https://cloud.r-project.org/")
+        shell: Rscript {0}
+
       - name: Run unit tests
         run: source("tests/testthat.R")
         shell: Rscript {0}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,8 @@ Imports:
   psych,
   qgraph,
   reshape2,
-  semPlot
+  semPlot,
+  GPArotation
 Remotes:
   jasp-stats/jaspBase,
   jasp-stats/jaspGraphs


### PR DESCRIPTION
Relates to: https://github.com/jasp-stats/INTERNAL-jasp/issues/1358

The tests failed because of missing GPArotation package which meant the analysis used a default rotation.

On my Fork the unit test fails on Ubuntu because there is some issue with igraph. I am not sure how to fix it other than skipping this test on Ubuntu. @vandenman any ideas? 