### PR TITLE
Fixing the Slider Label

### DIFF
--- a/R/exploratoryfactoranalysis.R
+++ b/R/exploratoryfactoranalysis.R
@@ -228,7 +228,7 @@ ExploratoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
     return()
 
   loatab <- createJaspTable(gettext("Factor Loadings"))
-  loatab$dependOn(c("highlightText", "factorLoadingsSort"))
+  loatab$dependOn(c("loadingsThreshold", "factorLoadingsSort"))
   loatab$position <- 2
 
   loatab$addColumnInfo(name = "var", title = "", type = "string")
@@ -253,7 +253,7 @@ ExploratoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
   }
 
   loadings <- unclass(loads)
-  loadings[abs(loads) < options[["highlightText"]]] <- NA_real_
+  loadings[abs(loads) < options[["loadingsThreshold"]]] <- NA_real_
 
   df <- cbind.data.frame(
     var = rownames(loads),
@@ -275,7 +275,7 @@ ExploratoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
 .efaStructureTable <- function(modelContainer, dataset, options, ready) {
   if (!options[["incl_structure"]] || !is.null(modelContainer[["strtab"]])) return()
   strtab <- createJaspTable(gettext("Factor Loadings (Structure Matrix)"))
-  strtab$dependOn(c("highlightText", "incl_structure"))
+  strtab$dependOn(c("loadingsThreshold", "incl_structure"))
   strtab$position <- 2.5
   strtab$addColumnInfo(name = "var", title = "", type = "string")
   modelContainer[["strtab"]] <- strtab
@@ -297,12 +297,12 @@ ExploratoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
 
   for (i in 1:ncol(loads)) {
     # fix weird "all true" issue
-    if (all(abs(loads[, i]) < options$highlightText)) {
+    if (all(abs(loads[, i]) < options$loadingsThreshold)) {
       strtab$addColumnInfo(name = paste0("c", i), title = gettextf("Factor %i", i), type = "string")
       strtab[[paste0("c", i)]] <- rep("", nrow(loads))
     } else {
       strtab$addColumnInfo(name = paste0("c", i), title = gettextf("Factor %i", i), type = "number", format = "dp:3")
-      strtab[[paste0("c", i)]] <- ifelse(abs(loads[, i]) < options$highlightText, NA, loads[ ,i])
+      strtab[[paste0("c", i)]] <- ifelse(abs(loads[, i]) < options$loadingsThreshold, NA, loads[ ,i])
     }
   }
 }
@@ -449,7 +449,7 @@ ExploratoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
   # Create plot object
   n_var <- length(options$variables)
   path <- createJaspPlot(title = gettext("Path Diagram"), width = 480, height = ifelse(n_var < 2, 300, 1 + 299 * (n_var / 5)))
-  path$dependOn(c("incl_pathDiagram", "highlightText"))
+  path$dependOn(c("incl_pathDiagram", "loadingsThreshold"))
   path$position <- 7
   modelContainer[["path"]] <- path
   if (!ready || modelContainer$getError()) return()
@@ -583,7 +583,7 @@ ExploratoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
     mar                 = c(5,10,5,12),
     normalize           = FALSE,
     label.fill.vertical = 0.75,
-    cut                 = options$highlightText,
+    cut                 = options$loadingsThreshold,
     bg                  = "transparent"
   ))
 

--- a/R/principalcomponentanalysis.R
+++ b/R/principalcomponentanalysis.R
@@ -205,7 +205,7 @@ PrincipalComponentAnalysis <- function(jaspResults, dataset, options, ...) {
 .pcaLoadingsTable <- function(modelContainer, dataset, options, ready) {
   if (!is.null(modelContainer[["loatab"]])) return()
   loatab <- createJaspTable(gettext("Component Loadings"))
-  loatab$dependOn(c("highlightText", "componentLoadingsSort"))
+  loatab$dependOn(c("loadingsThreshold", "componentLoadingsSort"))
   loatab$position <- 2
   loatab$addColumnInfo(name = "var", title = "", type = "string")
   modelContainer[["loatab"]] <- loatab
@@ -231,7 +231,7 @@ PrincipalComponentAnalysis <- function(jaspResults, dataset, options, ...) {
   }
 
   loadings <- unclass(loads)
-  loadings[abs(loads) < options[["highlightText"]]] <- NA_real_
+  loadings[abs(loads) < options[["loadingsThreshold"]]] <- NA_real_
 
   df <- cbind.data.frame(
     var = rownames(loads),
@@ -373,7 +373,7 @@ PrincipalComponentAnalysis <- function(jaspResults, dataset, options, ...) {
   # Create plot object
   n_var <- length(options$variables)
   path <- createJaspPlot(title = gettext("Path Diagram"), width = 480, height = ifelse(n_var < 2, 300, 1 + 299 * (n_var / 5)))
-  path$dependOn(c("incl_pathDiagram", "highlightText"))
+  path$dependOn(c("incl_pathDiagram", "loadingsThreshold"))
   modelContainer[["path"]] <- path
   if (!ready || modelContainer$getError()) return()
 
@@ -501,7 +501,7 @@ PrincipalComponentAnalysis <- function(jaspResults, dataset, options, ...) {
     mar                 = c(5,10,5,12),
     normalize           = FALSE,
     label.fill.vertical = 0.75,
-    cut                 = options$highlightText,
+    cut                 = options$loadingsThreshold,
     bg                  = "transparent"
   ))
 

--- a/inst/qml/ExploratoryFactorAnalysis.qml
+++ b/inst/qml/ExploratoryFactorAnalysis.qml
@@ -143,23 +143,23 @@ Form
 	{
 		title: qsTr("Output Options")
 
-        Group {
-            RadioButtonGroup
-            {
-                name: "factorLoadingsSort"
-                title: qsTr("Order factor loadings by")
-                RadioButton	{ name: "sortByFactorSize";		label: qsTr("Factor size");		checked: true		}
-                RadioButton	{ name: "sortByVariables";		label: qsTr("Variables")							}
-            }
+		Group {
+			RadioButtonGroup
+			{
+				name: "factorLoadingsSort"
+				title: qsTr("Order factor loadings by")
+				RadioButton	{ name: "sortByFactorSize";		label: qsTr("Factor size");		checked: true		}
+				RadioButton	{ name: "sortByVariables";		label: qsTr("Variables")							}
+			}
 
-            Slider {
-                name: "loadingsThreshold"
-                label: qsTr("Loadings threshold")
-                value: 0.4
-                vertical: false
-            }
+			Slider {
+				name: "loadingsThreshold"
+				label: qsTr("Loadings threshold")
+				value: 0.4
+				vertical: false
+			}
 
-        }
+		}
 
 		Group
 		{

--- a/inst/qml/ExploratoryFactorAnalysis.qml
+++ b/inst/qml/ExploratoryFactorAnalysis.qml
@@ -143,22 +143,26 @@ Form
 	{
 		title: qsTr("Output Options")
 
-		Slider {
-			name: "highlightText"
-			title: qsTr("Highlight")
-			value: 0.4
-		}
+        Group {
+            RadioButtonGroup
+            {
+                name: "factorLoadingsSort"
+                title: qsTr("Order factor loadings by")
+                RadioButton	{ name: "sortByFactorSize";		label: qsTr("Factor size");		checked: true		}
+                RadioButton	{ name: "sortByVariables";		label: qsTr("Variables")							}
+            }
+
+            Slider {
+                name: "loadingsThreshold"
+                label: qsTr("Loadings threshold")
+                value: 0.4
+                vertical: false
+            }
+
+        }
 
 		Group
 		{
-			RadioButtonGroup
-			{
-				name: "factorLoadingsSort"
-				title: qsTr("Order factor loadings by")
-				RadioButton	{ name: "sortByFactorSize";		label: qsTr("Factor size");		checked: true		}
-				RadioButton	{ name: "sortByVariables";		label: qsTr("Variables")							}
-			}
-
 			Group
 			{
 				title: qsTr("Tables")

--- a/inst/qml/PrincipalComponentAnalysis.qml
+++ b/inst/qml/PrincipalComponentAnalysis.qml
@@ -37,14 +37,14 @@ Form
 	{
 		preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
 		AvailableVariablesList { name: "allVariablesList" }
-        AssignedVariablesList
-        {
-            id: variables
-            name: "variables"
-            title: qsTr("Variables")
-            suggestedColumns: ["scale"]
-            allowedColumns: ["scale"]
-        }
+		AssignedVariablesList
+		{
+			id: variables
+			name: "variables"
+			title: qsTr("Variables")
+			suggestedColumns: ["scale"]
+			allowedColumns: ["scale"]
+		}
 	}
 
 
@@ -68,16 +68,16 @@ Form
 		}
 	}
 
-    Group
-    {
-        RadioButtonGroup
-        {
-            name: "rotationMethod"
-            title: qsTr("Rotation")
-            RadioButton
-            {
-                value	: "orthogonal"
-                label	: qsTr("Orthogonal")
+	Group
+	{
+		RadioButtonGroup
+		{
+			name: "rotationMethod"
+			title: qsTr("Rotation")
+			RadioButton
+			{
+				value	: "orthogonal"
+				label	: qsTr("Orthogonal")
 				DropDown
 				{
 					name: "orthogonalSelector"
@@ -90,55 +90,55 @@ Form
 						{ label: "geominT"		, value: "geominT"		}
 					]
 				}
-            }
-            RadioButton
-            {
-                value	: "oblique"
-                label	: qsTr("Oblique")
-                checked	: true
-                DropDown { name: "obliqueSelector"; values: [ "promax", "oblimin", "simplimax", "bentlerQ", "biquartimin", "cluster", "geominQ" ] }
-            }
-        }
+			}
+			RadioButton
+			{
+				value	: "oblique"
+				label	: qsTr("Oblique")
+				checked	: true
+				DropDown { name: "obliqueSelector"; values: [ "promax", "oblimin", "simplimax", "bentlerQ", "biquartimin", "cluster", "geominQ" ] }
+			}
+		}
 
-        RadioButtonGroup
-        {
-            name: "basedOn"
-            title: qsTr("Base decomposition on")
-            RadioButton
-            {
-                value: "correlation"
-                label: qsTr("Correlation matrix")
-                checked: true
-            }
-            RadioButton
-            {
-                value: "covariance"
-                label: qsTr("Covariance matrix")
-            }
-        }
-    }
+		RadioButtonGroup
+		{
+			name: "basedOn"
+			title: qsTr("Base decomposition on")
+			RadioButton
+			{
+				value: "correlation"
+				label: qsTr("Correlation matrix")
+				checked: true
+			}
+			RadioButton
+			{
+				value: "covariance"
+				label: qsTr("Covariance matrix")
+			}
+		}
+	}
 
 	Section
 	{
 		title: qsTr("Output Options")
 
-        Group {
-            RadioButtonGroup
-            {
-                name: "componentLoadingsSort"
-                title: qsTr("Order component loadings by")
-                RadioButton	{ name: "sortByComponentSize";	label: qsTr("Component size");	checked: true		}
-                RadioButton	{ name: "sortByVariables";		label: qsTr("Variables")							}
-            }
+		Group {
+			RadioButtonGroup
+			{
+				name: "componentLoadingsSort"
+				title: qsTr("Order component loadings by")
+				RadioButton	{ name: "sortByComponentSize";	label: qsTr("Component size");	checked: true		}
+				RadioButton	{ name: "sortByVariables";		label: qsTr("Variables")							}
+			}
 
-            Slider
-            {
-                name: "loadingsThreshold"
-                label: qsTr("Loadings threshold")
-                value: 0.4
-                vertical: false
-            }
-        }
+			Slider
+			{
+				name: "loadingsThreshold"
+				label: qsTr("Loadings threshold")
+				value: 0.4
+				vertical: false
+			}
+		}
 
 		Group
 		{
@@ -166,17 +166,17 @@ Form
 		CheckBox 
 		{
 			debug: true
-            id: addPC
-            name: "addPC"
-            text: qsTr("Add PC scores to data")
-            enabled: variables.count > 1
+			id: addPC
+			name: "addPC"
+			text: qsTr("Add PC scores to data")
+			enabled: variables.count > 1
 
-            ComputedColumnField { 
-                name: 		"PCPrefix"
-                text: 		"Prefix: "
-                fieldWidth: 120
-                visible:    addPC.checked
-            }
-        }
+			ComputedColumnField { 
+				name: 		"PCPrefix"
+				text: 		"Prefix: "
+				fieldWidth: 120
+				visible:    addPC.checked
+			}
+		}
 	}
 }

--- a/inst/qml/PrincipalComponentAnalysis.qml
+++ b/inst/qml/PrincipalComponentAnalysis.qml
@@ -122,23 +122,26 @@ Form
 	{
 		title: qsTr("Output Options")
 
-		Slider
-		{
-			name: "highlightText"
-			title: qsTr("Highlight")
-			value: 0.4
-		}
+        Group {
+            RadioButtonGroup
+            {
+                name: "componentLoadingsSort"
+                title: qsTr("Order component loadings by")
+                RadioButton	{ name: "sortByComponentSize";	label: qsTr("Component size");	checked: true		}
+                RadioButton	{ name: "sortByVariables";		label: qsTr("Variables")							}
+            }
+
+            Slider
+            {
+                name: "loadingsThreshold"
+                label: qsTr("Loadings threshold")
+                value: 0.4
+                vertical: false
+            }
+        }
 
 		Group
 		{
-			RadioButtonGroup
-			{
-				name: "componentLoadingsSort"
-				title: qsTr("Order component loadings by")
-				RadioButton	{ name: "sortByComponentSize";	label: qsTr("Component size");	checked: true		}
-				RadioButton	{ name: "sortByVariables";		label: qsTr("Variables")							}
-			}
-
 			Group
 			{
 				title: qsTr("Table")

--- a/tests/testthat/test-exploratoryfactoranalysis.R
+++ b/tests/testthat/test-exploratoryfactoranalysis.R
@@ -9,7 +9,7 @@ context("Exploratory Factor Analysis")
 options <- jaspTools::analysisOptions("ExploratoryFactorAnalysis")
 options$factorMethod <- "manual"
 options$fitmethod <- "minres"
-options$highlightText <- 0.4
+options$loadingsThreshold <- 0.4
 options$incl_correlations <- TRUE
 options$incl_fitIndices <- TRUE
 options$incl_pathDiagram <- TRUE
@@ -108,7 +108,7 @@ test_that("factorLoadingsSort sort the factor loadings table", {
 
   options <- jaspTools::analysisOptions("ExploratoryFactorAnalysis")
   options$orthogonalSelector <- "varimax"
-  options$highlightText <- 0.2
+  options$loadingsThreshold <- 0.2
   options$variables <- paste0("x", 1:9)
 
   reference <- list(

--- a/tests/testthat/test-verified-exploratoryfactoranalysis.R
+++ b/tests/testthat/test-verified-exploratoryfactoranalysis.R
@@ -18,7 +18,7 @@ options$incl_screePlot <- TRUE
 options$variables <- c(paste("Question", 1:9, sep="_0"), paste("Question", 10:23, sep="_"))
 options$eigenValuesBox <- 1
 options$fitmethod <- "pa"
-options$highlightText <- 0.4
+options$loadingsThreshold <- 0.4
 options$obliqueSelector <- "oblimin"
 
 
@@ -122,7 +122,7 @@ test_that("Factor Characteristics table results match R, SPSS, SAS, MiniTab", {
 options <- jaspTools::analysisOptions("ExploratoryFactorAnalysis")
 options$factorMethod <- "manual"
 options$fitmethod <- "minres"
-options$highlightText <- 0.4
+options$loadingsThreshold <- 0.4
 options$incl_correlations <- TRUE
 options$incl_fitIndices <- TRUE
 options$incl_pathDiagram <- TRUE

--- a/tests/testthat/test-verified-principalcomponentanalysis.R
+++ b/tests/testthat/test-verified-principalcomponentanalysis.R
@@ -12,7 +12,7 @@ context("Principal Component Analysis -- Verification project")
 # https://jasp-stats.github.io/jasp-verification-project/factor.html
 options <- jaspTools::analysisOptions("PrincipalComponentAnalysis")
 options$PCPrefix <- ""
-options$highlightText <- 0.4
+options$loadingsThreshold <- 0.4
 options$orthogonalSelector <- "varimax"
 options$variables <- c(paste("Question", 1:9, sep="_0"), paste("Question", 10:23, sep="_"))
 options$factorMethod <- "parallelAnalysis"


### PR DESCRIPTION
→ This depends on this: https://github.com/jasp-stats/jasp-desktop/pull/4611

A few changes to fix the slider's label and orientation:

- Renamed the highlightedText to loadingsThreshold
- Rearranged some of the controls for better uniformity of the UI
- Made the Slider horizontal

So, we go from these

![Screenshot 2021-09-06 at 14 35 06](https://user-images.githubusercontent.com/1290841/132218475-ae6570b1-bcfe-4dc9-a8cf-6bb292d29f86.png)

to these:

![Screenshot 2021-09-06 at 14 07 41](https://user-images.githubusercontent.com/1290841/132218502-4f4de4f0-e236-40b9-a20d-633222f83bd1.png)
![Screenshot 2021-09-06 at 14 07 30](https://user-images.githubusercontent.com/1290841/132218505-1f73cf0a-63ed-4e22-bd78-f013fedfcf0b.png)

I think some of these changes are pending for 0.15, right? I'm not sure.

P.S. I'm still looking around, but this looked like a fun exercise, so I went for it! 🙃
