### PR TITLE
Fix number of factors in parallel analysis

### DIFF
--- a/R/exploratoryfactoranalysis.R
+++ b/R/exploratoryfactoranalysis.R
@@ -151,7 +151,7 @@ ExploratoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
     # on the modelcontainer.
     if (ncomp == 0)
       stop(
-        gettext("No components with an eigenvalue > "), options$eigenValuesBox, ". ",
+        gettext("No factors with an eigenvalue > "), options$eigenValuesBox, ". ",
         gettext("Maximum observed eigenvalue: "), round(max(pa$fa.values), 3)
       )
     return(ncomp)

--- a/R/exploratoryfactoranalysis.R
+++ b/R/exploratoryfactoranalysis.R
@@ -144,7 +144,7 @@ ExploratoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
   if (options$factorMethod == "manual")           return(options$numberOfFactors)
   pa <- try(psych::fa.parallel(dataset, plot = FALSE))
   if (inherits(pa, "try-error"))                  return(1)
-  if (options$factorMethod == "parallelAnalysis") return(max(1, pa$ncomp))
+  if (options$factorMethod == "parallelAnalysis") return(max(1, pa$nfact))
   if (options$factorMethod == "eigenValues") {
     ncomp <- sum(pa$fa.values > options$eigenValuesBox)
     # I can use stop() because it's caught by the try and the message is put on

--- a/tests/testthat/test-verified-exploratoryfactoranalysis.R
+++ b/tests/testthat/test-verified-exploratoryfactoranalysis.R
@@ -9,14 +9,14 @@ context("Exploratory Factor Analysis -- Verification project")
 ## Testing Questionnaire data
 
 options <- jaspTools::analysisOptions("ExploratoryFactorAnalysis")
-options$factorMethod <- "parallelAnalysis"
+options$factorMethod <- "manual"
 options$rotationMethod <- "orthogonal"
 options$orthogonalSelector <- "varimax"
 options$kmotest <- TRUE
 options$bartest <- TRUE
 options$incl_screePlot <- TRUE
 options$variables <- c(paste("Question", 1:9, sep="_0"), paste("Question", 10:23, sep="_"))
-options$eigenValuesBox <- 1
+options$numberOfFactors <- 4
 options$fitmethod <- "pa"
 options$highlightText <- 0.4
 options$obliqueSelector <- "oblimin"


### PR DESCRIPTION
This patch fixes a mistake where the number of factors chosen via parallel analysis (the default method) is incorrectly set to the number of principal components instead