### PR TITLE
jaspFactor (PCA and EFA): add options for parallel analysis, adjust scree plot, fix bug in correlation table

### DIFF
--- a/R/exploratoryfactoranalysis.R
+++ b/R/exploratoryfactoranalysis.R
@@ -109,7 +109,8 @@ ExploratoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
   } else {
     modelContainer <- createJaspContainer()
     modelContainer$dependOn(c("rotationMethod", "orthogonalSelector", "obliqueSelector", "variables", "factorMethod",
-                              "eigenValuesBox", "numberOfFactors", "missingValues", "basedOn", "fitmethod"))
+                              "eigenValuesBox", "numberOfFactors", "missingValues", "basedOn", "fitmethod",
+                              "parallelMethod"))
     jaspResults[["modelContainer"]] <- modelContainer
   }
 
@@ -145,11 +146,11 @@ ExploratoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
   pa <- try(psych::fa.parallel(dataset, plot = FALSE, fa = options$parallelMethod))
   if (inherits(pa, "try-error"))        return(1)
   if (options$factorMethod == "parallelAnalysis") {
-    if (options$parallelMethod == "pc") return(max(1, fa$ncomp))
-    if (options$parallelMethod == "fa") return(max(1, fa$nfact))
+    if (options$parallelMethod == "pc") return(max(1, pa$ncomp))
+    if (options$parallelMethod == "fa") return(max(1, pa$nfact))
   }
   if (options$factorMethod == "eigenValues") {
-    ncomp <- sum(pa$fa.values > options$eigenValuesBox)
+    ncomp <- sum(pa$pa.values > options$eigenValuesBox)
     # I can use stop() because it's caught by the try and the message is put on
     # on the modelcontainer.
     if (ncomp == 0)

--- a/R/exploratoryfactoranalysis.R
+++ b/R/exploratoryfactoranalysis.R
@@ -150,7 +150,7 @@ ExploratoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
     if (options$parallelMethod == "fa") return(max(1, pa$nfact))
   }
   if (options$factorMethod == "eigenValues") {
-    ncomp <- sum(pa$pa.values > options$eigenValuesBox)
+    ncomp <- sum(pa$pc.values > options$eigenValuesBox)
     # I can use stop() because it's caught by the try and the message is put on
     # on the modelcontainer.
     if (ncomp == 0)
@@ -434,7 +434,7 @@ ExploratoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
     evs <- c(pa$fa.values, pa$fa.sim)
 
   } else { # in all other cases we use the initial eigenvalues for the plot, aka the pca ones
-    if (is.na(pa$pc.sim)) {
+    if (anyNA(pa$pc.sim)) {
       pa <- psych::fa.parallel(dataset, plot = FALSE, fa = "pc")
     }
     evs <- c(pa$pc.values, pa$pc.sim)
@@ -450,7 +450,7 @@ ExploratoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
   plt <-
     ggplot2::ggplot(df, ggplot2::aes(x = id, y = ev, linetype = type, shape = type)) +
     ggplot2::geom_line(na.rm = TRUE) +
-    ggplot2::labs(x = gettext("Component"), y = gettext("Eigenvalue")) +
+    ggplot2::labs(x = gettext("Factor"), y = gettext("Eigenvalue")) +
     ggplot2::geom_hline(yintercept = options$eigenValuesBox)
 
 

--- a/R/principalcomponentanalysis.R
+++ b/R/principalcomponentanalysis.R
@@ -8,7 +8,7 @@
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
@@ -319,14 +319,14 @@ PrincipalComponentAnalysis <- function(jaspResults, dataset, options, ...) {
 
   if (pcaResult$factors == 1 || options$rotationMethod == "orthogonal") return()
   # no factor correlation matrix when rotation specifiec uncorrelated factors!
-  cors <- zapsmall(pcaResults$Phi)
+  cors <- zapsmall(pcaResult$Phi)
   dims <- ncol(cors)
 
 
-  cortab[["col"]] <- paste0(coltitle, 1:dims)
+  cortab[["col"]] <- paste("Component", 1:dims)
 
   for (i in 1:dims) {
-    thisname <- paste0(coltitle, i)
+    thisname <- paste("Component", i)
     cortab$addColumnInfo(name = thisname, title = thisname, type = "number", format = "dp:3")
     cortab[[thisname]] <- cors[,i]
   }
@@ -356,7 +356,7 @@ PrincipalComponentAnalysis <- function(jaspResults, dataset, options, ...) {
     evs <- c(pa$fa.values, pa$fa.sim)
 
   } else { # in all other cases we use the initial eigenvalues for the plot, aka the pca ones
-    if (is.na(pa$pc.sim)) {
+    if (anyNA(pa$pc.sim)) {
       pa <- psych::fa.parallel(dataset, plot = FALSE, fa = "pc")
     }
     evs <- c(pa$pc.values, pa$pc.sim)

--- a/R/principalcomponentanalysis.R
+++ b/R/principalcomponentanalysis.R
@@ -105,7 +105,8 @@ PrincipalComponentAnalysis <- function(jaspResults, dataset, options, ...) {
   } else {
     modelContainer <- createJaspContainer()
     modelContainer$dependOn(c("rotationMethod", "orthogonalSelector", "obliqueSelector", "variables", "factorMethod",
-                              "eigenValuesBox", "numberOfFactors", "missingValues", "basedOn"))
+                              "eigenValuesBox", "numberOfFactors", "missingValues", "basedOn",
+                              "parallelMethod"))
     jaspResults[["modelContainer"]] <- modelContainer
   }
 

--- a/inst/Upgrades.qml
+++ b/inst/Upgrades.qml
@@ -1,0 +1,35 @@
+import QtQuick 		2.12
+import JASP.Module 	1.0
+
+Upgrades
+{
+
+	Upgrade
+	{
+		functionName:       "PrincipalComponentAnalysis"
+		fromVersion:		"0.16"
+		toVersion:			"0.17"
+
+		ChangeSetValue
+		{
+			condition:	function(options) { return options["parallelMethod"] === undefined }
+			name:		"parallelMethod"
+			jsonValue:	"pc"
+		}
+	}
+
+
+	Upgrade
+	{
+		functionName:       "ExploratoryFactorAnalysis"
+		fromVersion:		"0.16"
+		toVersion:			"0.17"
+
+		ChangeSetValue
+		{
+			condition:	function(options) { return options["parallelMethod"] === undefined }
+			name:		"parallelMethod"
+			jsonValue:	"fa"
+		}
+	}
+}

--- a/inst/Upgrades.qml
+++ b/inst/Upgrades.qml
@@ -23,7 +23,7 @@ Upgrades
 	{
 		functionName:       "ExploratoryFactorAnalysis"
 		fromVersion:		"0.16"
-		toVersion:			"0.17"
+		toVersion:			"0.16.1"
 
 		ChangeSetValue
 		{

--- a/inst/Upgrades.qml
+++ b/inst/Upgrades.qml
@@ -8,7 +8,7 @@ Upgrades
 	{
 		functionName:       "PrincipalComponentAnalysis"
 		fromVersion:		"0.16"
-		toVersion:			"0.17"
+		toVersion:			"0.16.1"
 
 		ChangeSetValue
 		{

--- a/inst/qml/ExploratoryFactorAnalysis.qml
+++ b/inst/qml/ExploratoryFactorAnalysis.qml
@@ -52,7 +52,26 @@ Form
 			name: "factorMethod"
 			title: qsTr("Number of Factors")
 			RadioButton { value: "parallelAnalysis";	label: qsTr("Parallel analysis");  checked: true	}
-			RadioButton
+
+            RadioButtonGroup
+            {
+                name:   "parallelMethod"
+                title:  qsTr("")
+
+                RadioButton
+                {
+                    value:      "pc"
+                    label:      qsTr("Based on PC")
+                    checked:    true
+                }
+                RadioButton
+                {
+                    value: "fa"
+                    label: qsTr("Based on FA")
+                }
+            }
+
+            RadioButton
 			{
 				value: "eigenValues";					label: qsTr("Eigenvalues")
 				DoubleField { name: "eigenValuesBox"; label: qsTr("Eigenvalues above"); defaultValue: 1; decimals: 1 }

--- a/inst/qml/ExploratoryFactorAnalysis.qml
+++ b/inst/qml/ExploratoryFactorAnalysis.qml
@@ -194,7 +194,16 @@ Form
 			{
 				title: qsTr("Plots")
 				CheckBox { name: "incl_pathDiagram";	label: qsTr("Path diagram")				}
-				CheckBox { name: "incl_screePlot";		label: qsTr("Scree plot")				}
+				CheckBox {
+					name:  "incl_screePlot";
+					label: qsTr("Scree plot")
+
+					CheckBox {
+						name:		"screeDispParallel"
+						label:		qsTr("Parallel analysis results")
+						checked:	true
+					}
+				}
 			}
 		}
 

--- a/inst/qml/ExploratoryFactorAnalysis.qml
+++ b/inst/qml/ExploratoryFactorAnalysis.qml
@@ -51,23 +51,28 @@ Form
 		{
 			name: "factorMethod"
 			title: qsTr("Number of Factors")
-			RadioButton { value: "parallelAnalysis";	label: qsTr("Parallel analysis");  checked: true	}
-
-            RadioButtonGroup
+            RadioButton
             {
-                name:   "parallelMethod"
-                title:  qsTr("")
+                value:      "parallelAnalysis";
+                label:      qsTr("Parallel analysis");
+                checked:    true
 
-                RadioButton
+                RadioButtonGroup
                 {
-                    value:      "pc"
-                    label:      qsTr("Based on PC")
-                    checked:    true
-                }
-                RadioButton
-                {
-                    value: "fa"
-                    label: qsTr("Based on FA")
+                    name:   "parallelMethod"
+                    title:  qsTr("")
+
+                    RadioButton
+                    {
+                        value:      "pc"
+                        label:      qsTr("Based on PC")
+                        checked:    true
+                    }
+                    RadioButton
+                    {
+                        value: "fa"
+                        label: qsTr("Based on FA")
+                    }
                 }
             }
 

--- a/inst/qml/PrincipalComponentAnalysis.qml
+++ b/inst/qml/PrincipalComponentAnalysis.qml
@@ -166,7 +166,16 @@ Form
 			{
 				title: qsTr("Plots")
 				CheckBox { name: "incl_pathDiagram";	label: qsTr("Path diagram")				}
-				CheckBox { name: "incl_screePlot";		label: qsTr("Scree plot")				}
+				CheckBox {
+					name:  "incl_screePlot";
+					label: qsTr("Scree plot")
+
+					CheckBox {
+						name:		"screeDispParallel"
+						label:		qsTr("Parallel analysis results")
+						checked:	true
+					}
+				}
 			}
 		}
 

--- a/inst/qml/PrincipalComponentAnalysis.qml
+++ b/inst/qml/PrincipalComponentAnalysis.qml
@@ -58,15 +58,14 @@ Form
 
             RadioButtonGroup
             {
-                name:               "parallelMethod"
-                title:              qsTr("")
-//                childrenOnSameRow:  true
+                name:  "parallelMethod"
+                title: qsTr("")
 
                 RadioButton
                 {
-                    value:      "pc"
-                    label:      qsTr("Based on PC")
-                    checked:    true
+                    value:   "pc"
+                    label:   qsTr("Based on PC")
+                    checked: true
                 }
                 RadioButton
                 {

--- a/inst/qml/PrincipalComponentAnalysis.qml
+++ b/inst/qml/PrincipalComponentAnalysis.qml
@@ -55,6 +55,25 @@ Form
 		RadioButton
 		{
 			value: "parallelAnalysis"; label: qsTr("Parallel analysis"); checked: true
+
+            RadioButtonGroup
+            {
+                name:               "parallelMethod"
+                title:              qsTr("")
+//                childrenOnSameRow:  true
+
+                RadioButton
+                {
+                    value:      "pc"
+                    label:      qsTr("Based on PC")
+                    checked:    true
+                }
+                RadioButton
+                {
+                    value: "fa"
+                    label: qsTr("Based on FA")
+                }
+            }
 		}
 		RadioButton
 		{

--- a/tests/testthat/test-exploratoryfactoranalysis.R
+++ b/tests/testthat/test-exploratoryfactoranalysis.R
@@ -29,7 +29,7 @@ results <- jaspTools::runAnalysis("ExploratoryFactorAnalysis", "debug.csv", opti
 test_that("Factor Correlations table results match", {
   table <- results[["results"]][["modelContainer"]][["collection"]][["modelContainer_cortab"]][["data"]]
   jaspTools::expect_equal_tables(table,
-                      list(1, -0.0849326, "Factor 1", -0.0849326, 1, "Factor 2"))
+                                 list(1, -0.0736228, "Factor 1", -0.0736228, 1, "Factor 2"))
 })
 
 test_that("Factor Characteristics table results match", {
@@ -157,4 +157,56 @@ test_that("Estimation options do not crash", {
     testthat::expect(is.null(results[["results"]][["error"]]),
                      sprintf("Estimation with method '%s' crashes", fitmethod))
   }
+})
+
+
+options <- jaspTools::analysisOptions("ExploratoryFactorAnalysis")
+options$factorMethod <- "parallelAnalysis"
+options$parallelMethod <- "pc"
+options$fitmethod <- "minres"
+options$highlightText <- 0.1
+options$incl_correlations <- TRUE
+options$incl_screePlot <- TRUE
+options$orthogonalSelector <- "none"
+options$rotationMethod <- "orthogonal"
+options$variables <- paste0("x", 1:9)
+set.seed(1)
+results <- runAnalysis("ExploratoryFactorAnalysis", "holzingerswineford.csv", options)
+
+test_that("Factor Characteristics table results match with parallel analysis based on PCs", {
+  table <- results[["results"]][["modelContainer"]][["collection"]][["modelContainer_eigtab"]][["data"]]
+  jaspTools::expect_equal_tables(table,
+                                 list("Factor 1", 0.314163998816933, 0.314163998816933, 2.82747598935239,
+                                      "Factor 2", 0.449126711506194, 0.134962712689261, 1.21466441420335,
+                                      "Factor 3", 0.539738017727465, 0.0906113062212709, 0.815501755991438
+                                 ))
+})
+
+test_that("Chi-squared Test table results match with parallel analysis based on PCs", {
+  table <- results[["results"]][["modelContainer"]][["collection"]][["modelContainer_goftab"]][["data"]]
+  jaspTools::expect_equal_tables(table,
+                                 list(22.5550491736693, 12, "Model", 0.0317499059313278))
+})
+
+test_that("Factor Loadings table results match with parallel analysis based on PCs", {
+  table <- results[["results"]][["modelContainer"]][["collection"]][["modelContainer_loatab"]][["data"]]
+  jaspTools::expect_equal_tables(table,
+                                 list(0.57552287197933, 0.16858001566767, 0.342210768279291, 0.523245992219849,
+                                      "x1", 0.308426854688606, "", 0.388394269653172, 0.744772821204661,
+                                      "x2", 0.400354070864591, 0.30942956544643, 0.444319828761981,
+                                      0.546549851738708, "x3", 0.768508957341882, -0.354895458997614,
+                                      -0.106671680536983, 0.272064348239582, "x4", 0.750543052745831,
+                                      -0.404369058055611, -0.164016362264787, 0.246269423771613, "x5",
+                                      0.763025590432945, -0.326669752718025, "", 0.308644745749135,
+                                      "x6", 0.307604731575466, 0.432831609311044, -0.486405923245351,
+                                      0.481445404925434, "x7", 0.393821088746758, 0.540664836861347,
+                                      -0.269738272928661, 0.479827748357475, "x8", 0.504966416074441,
+                                      0.453220919172841, "", 0.539538616482753, "x9"))
+})
+
+test_that("Scree plot matches", {
+  skip("Scree plot check does not work because some data is simulated (non-deterministic).")
+  plotName <- results[["results"]][["modelContainer"]][["collection"]][["modelContainer_scree"]][["data"]]
+  testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
+  jaspTools::expect_equal_plots(testPlot, "scree-plot")
 })

--- a/tests/testthat/test-verified-exploratoryfactoranalysis.R
+++ b/tests/testthat/test-verified-exploratoryfactoranalysis.R
@@ -141,7 +141,7 @@ results <- jaspTools::runAnalysis("ExploratoryFactorAnalysis", "debug.csv", opti
 test_that("Factor Correlations table results match", {
   table <- results[["results"]][["modelContainer"]][["collection"]][["modelContainer_cortab"]][["data"]]
   jaspTools::expect_equal_tables(table,
-                      list(1, -0.0849326, "Factor 1", -0.0849326, 1, "Factor 2"))
+                                 list(1, -0.0736228, "Factor 1", -0.0736228, 1, "Factor 2"))
 })
 
 test_that("Factor Characteristics table results match", {


### PR DESCRIPTION
New Features: 

- new option for parallel analysis: 1) can be based on FA or 2) PCA
- scree plot is is adjusted to show the parallel analysis based on FA only when parallel analysis with FA is chosen to determine the number of factors, in all other cases the scree plot shows the parallel analysis with the initial eigenvalues (which are the ones from a parallel analysis based on the PCs), fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1559
- new and updated unit tests

Bug fixes:

- the factor correlation matrix showed the correlations of the estimated factor scores (r.scores), which is incorrect. That was visible when orthogonal rotations resulted in a correlation table with non zero correlations (which should be impossible). Now we are using the proper factor intercorrelations (Phi matrix).
Attached the screenshots from the psych help.
![Screenshot 2021-10-13 at 11 16 35](https://user-images.githubusercontent.com/38500953/137104583-cfb2c2d4-ed32-401f-b7f3-89b111af0529.png)
![Screenshot 2021-10-13 at 11 16 27](https://user-images.githubusercontent.com/38500953/137104590-64bddf34-669e-4af4-8e76-f76ab1961a6b.png)

Other:

- The features and fixes address some point from here: https://github.com/jasp-stats/jasp-issues/issues/1319#issue-908295102
- The verification website should be updated in regards to EFA and PCA.

Further topics:
a) the scree plot now always shows the results from a parallel analysis, even if no parallel analysis was used to determine the number of factors, would we just want the initial eigenvalues then? 
b) the parallel analysis for a PCA (as well as the FA) can now be based on components or factors. I know that this is used at least for EFAs, I have no idea if it makes sense for a PCA to do a parallel analysis based on factors. 