### PR TITLE
Fixed label in the rotated solution of the PCA output

### DIFF
--- a/R/principalcomponentanalysis.R
+++ b/R/principalcomponentanalysis.R
@@ -275,7 +275,7 @@ PrincipalComponentAnalysis <- function(jaspResults, dataset, options, ...) {
     eigtab$addColumnInfo(name = "eigvU", title = gettext("Eigenvalue"),      type = "number", overtitle = overTitleA)
     eigtab$addColumnInfo(name = "propU", title = gettext("Proportion var."), type = "number", overtitle = overTitleA)
     eigtab$addColumnInfo(name = "cumpU", title = gettext("Cumulative"),      type = "number", overtitle = overTitleA)
-    eigtab$addColumnInfo(name = "eigvR", title = gettext("Variance explained"), type = "number", overtitle = overTitleB)
+    eigtab$addColumnInfo(name = "eigvR", title = gettext("Eigenvalue"), type = "number", overtitle = overTitleB)
     eigtab$addColumnInfo(name = "propR", title = gettext("Proportion var."), type = "number", overtitle = overTitleB)
     eigtab$addColumnInfo(name = "cumpR", title = gettext("Cumulative"),      type = "number", overtitle = overTitleB)
   } else {

--- a/R/principalcomponentanalysis.R
+++ b/R/principalcomponentanalysis.R
@@ -275,7 +275,7 @@ PrincipalComponentAnalysis <- function(jaspResults, dataset, options, ...) {
     eigtab$addColumnInfo(name = "eigvU", title = gettext("Eigenvalue"),      type = "number", overtitle = overTitleA)
     eigtab$addColumnInfo(name = "propU", title = gettext("Proportion var."), type = "number", overtitle = overTitleA)
     eigtab$addColumnInfo(name = "cumpU", title = gettext("Cumulative"),      type = "number", overtitle = overTitleA)
-    eigtab$addColumnInfo(name = "eigvR", title = gettext("Eigenvalue"), type = "number", overtitle = overTitleB)
+    eigtab$addColumnInfo(name = "eigvR", title = gettext("SumSq. Loadings"), type = "number", overtitle = overTitleB)
     eigtab$addColumnInfo(name = "propR", title = gettext("Proportion var."), type = "number", overtitle = overTitleB)
     eigtab$addColumnInfo(name = "cumpR", title = gettext("Cumulative"),      type = "number", overtitle = overTitleB)
   } else {


### PR DESCRIPTION
The column showing the eigenvalues of the rotated solution was mislabelled "Variance explained" but it should be labelled "Eigenvalue".