### PR TITLE
Fix unupgraded options

### DIFF
--- a/R/exploratoryfactoranalysis.R
+++ b/R/exploratoryfactoranalysis.R
@@ -129,6 +129,11 @@ exploratoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
 # If basedOn == mixed, the fa will be performed computing a tetrachoric or polychoric correlation matrix,
 # depending on the number of response categories of the ordinal variables.
 .efaComputeResults <- function(modelContainer, dataset, options, ready) {
+  baseOn <- switch(options[["basedOn"]],
+                   correlation = "cor",
+                   covariance  = "cov",
+                   mixed       = "mixed")
+
   efaResult <- try(
     psych::fa(
       r        = dataset,
@@ -136,7 +141,7 @@ exploratoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
       rotate   = ifelse(options$rotationMethod == "orthogonal", options$orthogonalSelector, options$obliqueSelector),
       scores   = TRUE,
       covar    = options$basedOn == "covariance",
-      cor      = options$basedOn,
+      cor      = baseOn,
       fm       = options$fitmethod
     )
   )

--- a/R/exploratoryfactoranalysis.R
+++ b/R/exploratoryfactoranalysis.R
@@ -135,7 +135,7 @@ exploratoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
       nfactors = .efaGetNComp(dataset, options),
       rotate   = ifelse(options$rotationMethod == "orthogonal", options$orthogonalSelector, options$obliqueSelector),
       scores   = TRUE,
-      covar    = options$basedOn == "cov",
+      covar    = options$basedOn == "covariance",
       cor      = options$basedOn,
       fm       = options$fitmethod
     )

--- a/inst/qml/ExploratoryFactorAnalysis.qml
+++ b/inst/qml/ExploratoryFactorAnalysis.qml
@@ -160,13 +160,13 @@ Form
 			title: qsTr("Base analysis on")
 			RadioButton
 			{
-				value: "cor"
+				value: "correlation"
 				label: qsTr("Correlation matrix")
 				checked: true
 			}
 			RadioButton
 			{
-				value: "cov"
+				value: "covariance"
 				label: qsTr("Covariance matrix")
 			}
 			RadioButton


### PR DESCRIPTION
fixes https://github.com/jasp-stats/jasp-test-release/issues/2026

PR https://github.com/jasp-stats/jaspFactor/pull/75 changed option names but did not specify them in the upgrades, so now opening old JASP files fails. I just revert to the old names since there was actually no need to change the names in the PR.

Tagging @juliuspf so that he knows about this wrt https://github.com/jasp-stats/jaspFactor/pull/109

