### PR TITLE
Fix error messages for polychoric correlations

### DIFF
--- a/R/exploratoryfactoranalysis.R
+++ b/R/exploratoryfactoranalysis.R
@@ -172,8 +172,9 @@ exploratoryFactorAnalysisInternal <- function(jaspResults, dataset, options, ...
 
 # Modification here: if the estimation of the polychoric/tetrachoric correlation matrix fails with this specific error,
 # JASP replaces the internal error message with a more informative one.
-  if (isTryError(efaResult) && options[["basedOn"]] == "mixed" && (.extractErrorMessage(efaResult) == "missing value where TRUE/FALSE needed"
-                                || .extractErrorMessage(efaResult) == "attempt to set 'rownames' on an object with no dimensions")) {
+  if (isTryError(efaResult) && options[["analysisBasedOn"]] == "polyTetrachoricCorrelationMatrix" &&
+      (.extractErrorMessage(efaResult) == "missing value where TRUE/FALSE needed" ||
+       .extractErrorMessage(efaResult) == "attempt to set 'rownames' on an object with no dimensions")) {
     errmsgPolyCor <- gettextf(
       "Unfortunately, the estimation of the polychoric/tetrachoric correlation matrix failed.
       This might be due to a small sample size or variables not containing all response categories.
@@ -670,7 +671,7 @@ exploratoryFactorAnalysisInternal <- function(jaspResults, dataset, options, ...
   if (options[["screePlotParallelAnalysisResults"]]) {
 
     # Modification here:
-    # if "BasedOn = mixed", parallel analysis here will be based on the polychoric/tetrachoric
+    # if "analysisBasedOn = mixed", parallel analysis here will be based on the polychoric/tetrachoric
     # correlation matrix.
 
     if (options[["analysisBasedOn"]] == "polyTetrachoricCorrelationMatrix") {

--- a/R/principalcomponentanalysis.R
+++ b/R/principalcomponentanalysis.R
@@ -155,11 +155,16 @@ principalComponentAnalysisInternal <- function(jaspResults, dataset, options, ..
       scores   = TRUE,
       covar    = options$analysisBasedOn == "covarianceMatrix",
       cor      = corMethod
-    )
-  )
+    ))
 
   if (isTryError(pcaResult)) {
     errmsg <- gettextf("Estimation failed. Internal error message: %s", .extractErrorMessage(pcaResult))
+    # when polychoric corr matrix is used, the warning generated here is useful to know for the user
+    warns <- warnings()
+    warnmsg <- warns[grep("polychoric", warns)]
+    if (length(warnmsg) > 0) {
+      errmsg <- paste(errmsg, "\n Warning in: ", warnmsg, names(warnmsg))
+    }
     modelContainer$setError(errmsg)
   }
 


### PR DESCRIPTION
workaround that fixes https://github.com/jasp-stats/jasp-issues/issues/2206

In essence, it is just more informative error messages. The real work would have to be done by the `psych` package that does not allow variables with fewer response categories than the rest into the analysis. 