### PR TITLE
Change default extraction method for factor analysis to be based on factors (instead of principal components)

### DIFF
--- a/inst/qml/ExploratoryFactorAnalysis.qml
+++ b/inst/qml/ExploratoryFactorAnalysis.qml
@@ -56,13 +56,13 @@ Form
 					RadioButton
 					{
 						value:		"principalComponentBased"
-						label:		qsTr("Based on PC")
+						label:		qsTr("Based on principal components")
 						checked:	true
 					}
 					RadioButton
 					{
 						value: "factorBased"
-						label: qsTr("Based on FA")
+						label: qsTr("Based on factors")
 					}
 				}
 				IntegerField

--- a/inst/qml/ExploratoryFactorAnalysis.qml
+++ b/inst/qml/ExploratoryFactorAnalysis.qml
@@ -57,12 +57,12 @@ Form
 					{
 						value:		"principalComponentBased"
 						label:		qsTr("Based on principal components")
-						checked:	true
 					}
 					RadioButton
 					{
 						value: "factorBased"
 						label: qsTr("Based on factors")
+						checked:	true
 					}
 				}
 				IntegerField


### PR DESCRIPTION
This also clarifies the labels for the parallel analysis, which were adjusted recently for the principal components analysis but not the factor analysis.