### PR TITLE
Updating variable types in QML: removing suggestedColumns, restrictin…

### DIFF
--- a/inst/qml/ConfirmatoryFactorAnalysis.qml
+++ b/inst/qml/ConfirmatoryFactorAnalysis.qml
@@ -49,7 +49,6 @@ Form
 			{
 				title: qsTr("Second-Order")
 				name:  "secondOrder"
-				suggestedColumns: []
 			}
 			preferredHeight: jaspTheme.defaultVariablesFormHeight / 3
 		}

--- a/inst/qml/ExploratoryFactorAnalysis.qml
+++ b/inst/qml/ExploratoryFactorAnalysis.qml
@@ -31,8 +31,7 @@ Form
 			id: variables
 			name: "variables"
 			title: qsTr("Variables")
-			suggestedColumns: ["scale","ordinal"]
-			allowedColumns: ["scale","ordinal"]
+			allowedColumns: ["scale"]
 		}
 	}
 

--- a/inst/qml/PrincipalComponentAnalysis.qml
+++ b/inst/qml/PrincipalComponentAnalysis.qml
@@ -31,8 +31,7 @@ Form
 			id: variables
 			name: "variables"
 			title: qsTr("Variables")
-			suggestedColumns: ["scale","ordinal"]
-			allowedColumns: ["scale", "ordinal"]
+			allowedColumns: ["scale"]
 		}
 	}
 


### PR DESCRIPTION
…g allowedColumns to 'scale' for EFA and PCA since the analysis automatically casts everything as numeric, anyway