### PR TITLE
Move funcs to jasp sem

### DIFF
--- a/R/confirmatoryfactoranalysis.R
+++ b/R/confirmatoryfactoranalysis.R
@@ -228,10 +228,10 @@ confirmatoryFactorAnalysisInternal <- function(jaspResults, dataset, options, ..
 
   cfaResult <- list()
 
-  cfaResult[["spec"]] <- .cfaCalcSpecs(dataset, options)
+  cfaResult[["spec"]] <- jaspSem:::.cfaCalcSpecs(dataset, options)
   # Recalculate the model
 
-  modObj <- .optionsToCFAMod(options, dataset, cfaResult)
+  modObj <- jaspSem:::.optionsToCFAMod(options, dataset, cfaResult)
   mod <- modObj$model
   cfaResult[["model"]] <- mod
   cfaResult[["model_simple"]] <- modObj$simple_model
@@ -1413,7 +1413,7 @@ confirmatoryFactorAnalysisInternal <- function(jaspResults, dataset, options, ..
 .cfaSyntax <- function(jaspResults, options, dataset, cfaResult) {
   if (is.null(cfaResult) || !options$lavaanSyntax || !is.null(jaspResults[["syntax"]])) return()
 
-  mod <- .optionsToCFAMod(options, dataset, cfaResult, FALSE)$model
+  mod <- jaspSem:::.optionsToCFAMod(options, dataset, cfaResult, FALSE)$model
 
   jaspResults[["syntax"]] <- createJaspHtml(mod, class = "jasp-code", position = 7, title = gettext("Model syntax"))
   jaspResults[["syntax"]]$dependOn(optionsFromObject = jaspResults[["maincontainer"]][["cfatab"]])
@@ -1558,76 +1558,6 @@ confirmatoryFactorAnalysisInternal <- function(jaspResults, dataset, options, ..
   jaspResults[["resRelTable"]] <- relTable
 
 }
-
-# delete once jaspSem is merged
-lavBootstrap <- function(fit, samples = 1000, standard = FALSE, typeStd = NULL) {
-  # Run bootstrap, track progress with progress bar
-  # Notes: faulty runs are simply ignored
-  # recommended: add a warning if not all boot samples are successful
-  # fit <- lavBootstrap(fit, samples = 1000)
-  # if (nrow(fit@boot$coef) < 1000)
-  #  tab$addFootnote(gettextf("Not all bootstrap samples were successful: CI based on %.0f samples.", nrow(fit@boot$coef)),
-  #                  "<em>Note.</em>")
-
-
-  coef_with_callback <- function(lav_object) {
-    # Progress bar is ticked every time coef() is evaluated, which happens once on the main object:
-    # https://github.com/yrosseel/lavaan/blob/77a568a574e4113245e2f6aff1d7c3120a26dd90/R/lav_bootstrap.R#L107
-    # and then every time on a successful bootstrap:
-    # https://github.com/yrosseel/lavaan/blob/77a568a574e4113245e2f6aff1d7c3120a26dd90/R/lav_bootstrap.R#L375
-    # i.e., samples + 1 times
-    progressbarTick()
-
-    return(lavaan::coef(lav_object))
-  }
-
-  coef_with_callback_std <- function(lav_object, typeStd) {
-    std <- lavaan::standardizedSolution(lav_object, type = typeStd)
-    out <- std$est.std
-
-    progressbarTick()
-
-    return(out)
-  }
-
-  startProgressbar(samples + 1)
-
-  if (!standard) {
-    bootres <- lavaan::bootstrapLavaan(object = fit, R = samples, FUN = coef_with_callback)
-  } else {
-    bootres <- lavaan::bootstrapLavaan(object = fit, R = samples, FUN = coef_with_callback_std, typeStd = typeStd)
-  }
-
-  # Add the bootstrap samples to the fit object
-  fit@boot       <- list(coef = bootres)
-  fit@Options$se <- "bootstrap"
-
-  # exclude error bootstrap runs
-  err_id <- attr(fit@boot$coef, "error.idx")
-  if (length(err_id) > 0L) {
-    fit@boot$coef <- fit@boot$coef[-err_id, , drop = FALSE]
-  }
-
-  # we actually need the SEs from the bootstrap not the SEs from ML or something
-  N <- nrow(fit@boot$coef)
-
-  # we multiply the var by (n-1)/n because lavaan actually uses n for the variance instead of n-1
-  if (!standard) {
-    # for unstandardized
-    fit@ParTable$se[fit@ParTable$free != 0] <- apply(fit@boot$coef, 2, sd) * sqrt((N-1)/N)
-  } else {
-    fit@ParTable$se <- apply(fit@boot$coef, 2, sd) * sqrt((N-1)/N)
-    # the standardized solution gives all estimates not only the unconstrained, so we need to change
-    # the free prameters in the partable and also change the estimate
-    fit@ParTable$free <- seq_len(ncol(fit@boot$coef))
-    std <- lavaan::standardizedSolution(fit, type = typeStd)
-    fit@ParTable$est <- std$est.std
-  }
-
-
-  return(fit)
-}
-
 
 .cfaAddScoresToData <- function(jaspResults, options, cfaResult, dataset) {
 

--- a/R/exploratoryfactoranalysis.R
+++ b/R/exploratoryfactoranalysis.R
@@ -19,8 +19,6 @@ exploratoryFactorAnalysisInternal <- function(jaspResults, dataset, options, ...
   jaspResults$addCitation("Revelle, W. (2018) psych: Procedures for Personality and Psychological Research, Northwestern University, Evanston, Illinois, USA, https://CRAN.R-project.org/package=psych Version = 1.8.12.")
 
 
-  # Read dataset
-  dataset <- .pcaAndEfaReadData(dataset, options)
   ready   <- length(options$variables) > 1
   # Handle dataset
   dataset <- .pcaAndEfaHandleData(dataset, options, ready)
@@ -76,7 +74,7 @@ exploratoryFactorAnalysisInternal <- function(jaspResults, dataset, options, ...
 # depending on the number of response categories of the ordinal variables.
 .efaComputeResults <- function(modelContainer, dataset, options, ready) {
 
-  corMethod <- switch(options[["analysisBasedOn"]],
+  corMethod <- switch(options[["baseDecompositionOn"]],
                       "correlationMatrix" = "cor",
                       "covarianceMatrix" = "cov",
                       "polyTetrachoricCorrelationMatrix" = "mixed")

--- a/R/exploratoryfactoranalysis.R
+++ b/R/exploratoryfactoranalysis.R
@@ -19,10 +19,13 @@ exploratoryFactorAnalysisInternal <- function(jaspResults, dataset, options, ...
   jaspResults$addCitation("Revelle, W. (2018) psych: Procedures for Personality and Psychological Research, Northwestern University, Evanston, Illinois, USA, https://CRAN.R-project.org/package=psych Version = 1.8.12.")
 
 
+  # Read dataset
+  dataset <- .pcaAndEfaReadData(dataset, options)
   ready   <- length(options$variables) > 1
   # Handle dataset
   dataset <- .pcaAndEfaHandleData(dataset, options, ready)
   .pcaAndEfaDataCovarianceCheck(dataset, options, ready)
+
 
   if (ready)
     .pcaCheckErrors(dataset, options, method = "efa")
@@ -73,7 +76,7 @@ exploratoryFactorAnalysisInternal <- function(jaspResults, dataset, options, ...
 # depending on the number of response categories of the ordinal variables.
 .efaComputeResults <- function(modelContainer, dataset, options, ready) {
 
-  corMethod <- switch(options[["baseDecompositionOn"]],
+  corMethod <- switch(options[["analysisBasedOn"]],
                       "correlationMatrix" = "cor",
                       "covarianceMatrix" = "cov",
                       "polyTetrachoricCorrelationMatrix" = "mixed")

--- a/R/principalcomponentanalysis.R
+++ b/R/principalcomponentanalysis.R
@@ -59,13 +59,12 @@ principalComponentAnalysisInternal <- function(jaspResults, dataset, options, ..
   if (!ready) return()
 
   if (options[["dataType"]] == "raw") {
+    dataset <- dataset[, unlist(options[["variables"]])] # reorder the columns to equal the order in the variables list, otherwise they will be sorted somewhat alphabetically
     if (options[["naAction"]] == "listwise") {
       dataset <- dataset[complete.cases(dataset), ]
-      dataset[] <- lapply(dataset, function(x) as.numeric(as.character(x))) # the psych-package wants data to be numeric
-      return(dataset)
-    } else {
-      return(.readDataSetToEnd(columns.as.numeric = unlist(options$variables)))
     }
+    dataset[] <- lapply(dataset, function(x) as.numeric(as.character(x))) # the psych-package wants data to be numeric
+    return(dataset)
   } else { # if variance covariance matrix as input
     columnIndices <- sapply(options$variables, jaspBase:::columnIndexInData) + 1 # cpp starts at 0
     # reorder the dataset columns because the columnIndices are determined based on the "unloaded" data,

--- a/jaspFactor.Rproj
+++ b/jaspFactor.Rproj
@@ -1,5 +1,5 @@
 Version: 1.0
-ProjectId: 5cc9ddfa-69dc-44cb-b072-af7608690805
+ProjectId: ec780552-3ce8-46f5-9c6d-e55f97eb08ff
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/renv.lock
+++ b/renv.lock
@@ -1236,7 +1236,7 @@
     },
     "cluster": {
       "Package": "cluster",
-      "Version": "2.1.8.1",
+      "Version": "2.1.8",
       "Source": "Repository",
       "VersionNote": "Last CRAN: 2.1.8 on 2024-12-10; 2.1.7 on 2024-12-06; 2.1.6 on 2023-11-30; 2.1.5 on 2023-11-27",
       "Date": "2025-03-11",

--- a/renv.lock
+++ b/renv.lock
@@ -1236,7 +1236,7 @@
     },
     "cluster": {
       "Package": "cluster",
-      "Version": "2.1.8",
+      "Version": "2.1.8.1",
       "Source": "Repository",
       "VersionNote": "Last CRAN: 2.1.8 on 2024-12-10; 2.1.7 on 2024-12-06; 2.1.6 on 2023-11-30; 2.1.5 on 2023-11-27",
       "Date": "2025-03-11",
@@ -2889,7 +2889,6 @@
       ],
       "Roxygen": "list(markdown = TRUE)",
       "RemoteType": "github",
-      "RemoteHost": "api.github.com",
       "RemoteUsername": "jasp-stats",
       "RemoteRepo": "jaspGraphs",
       "RemoteRef": "master",
@@ -2924,7 +2923,6 @@
         "SEMsens"
       ],
       "RemoteType": "github",
-      "RemoteHost": "api.github.com",
       "RemoteUsername": "jasp-stats",
       "RemoteRepo": "jaspSem",
       "RemoteRef": "master",


### PR DESCRIPTION
this accounts for some functions that are shared with jaspSem to be moved to jaspSem, because otherwise there would be circular referencing. 

also fixes https://github.com/jasp-stats/jasp-issues/issues/3600 by reordering the dataset columns according to the occurrence in the variables window. 